### PR TITLE
Js fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,8 @@
                   <value>../../../src/main/webapp/js</value>
                 </closureSourceMapLocationMapping>
               </closureSourceMapLocationMappings>
-              <closureSourceMapName>bundle.min.map.js</closureSourceMapName>
+	      <closureSourceMapName>bundle.min.map.js</closureSourceMapName>
+	      <closureUseTypesForOptimization>true</closureUseTypesForOptimization>
             </configuration>
             <goals>
               <goal>minify</goal>

--- a/src/main/webapp/js/basicview/basicview.js
+++ b/src/main/webapp/js/basicview/basicview.js
@@ -56,6 +56,14 @@ class BasicView {
   }
 
   /**
+   * Returns the raw content element.
+   * @return {!Element}
+   */
+  getCurrentContentElement() {
+    return /** @type {!Element} */ (googDom.getElement('content'));
+  }
+
+  /**
    * @param {?googSoy.data.SanitizedHtml} currentContent
    */
   setCurrentContent(currentContent) {
@@ -63,7 +71,8 @@ class BasicView {
   }
 
   /**
-   * Helper function for resetting and updating the whole page.
+   * Helper function for resetting and updating the whole page. Note that this
+   * will reset any JSAction listeners registered.
    */
   resetAndUpdate() {
     googDom.getDocument().documentElement.innerHTML =

--- a/src/main/webapp/js/basicview/basicview.js
+++ b/src/main/webapp/js/basicview/basicview.js
@@ -12,26 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/** @fileoverview The mini controller for college list view. */
+/** Basic view class for all view objects. */
 
-goog.module('finscholar.collegelistview');
-const {BasicView} = goog.require('basicview');
-const {collegelist} = goog.require('finscholar.collegelistview.templates');
+goog.module('basicview');
 
-/** The mini controller for college list view. */
-class CollegeListView extends BasicView {
-  constructor() {
-    super();
-  }
+/** Basic view class for all view objects. */
+class BasicView {
+  constructor() {}
 
   /**
    * Renders a college list view to the container.
    * @param {!Element} container The HTML container to load the view.
-   * @override
    */
-  async renderView(container) {
-    container.innerHTML = collegelist();
-  }
+  async renderView(container) {}
 }
 
-exports = {CollegeListView}
+exports = {BasicView}

--- a/src/main/webapp/js/basicview/basicview.js
+++ b/src/main/webapp/js/basicview/basicview.js
@@ -16,15 +16,65 @@
 
 goog.module('basicview');
 
+const googDom = goog.require('goog.dom');
+const googSoy = goog.require('goog.soy');
+const {root} = goog.require('basicview.templates');
+
+/** @const {string} */
+const DEFAULT_PAGE_TITLE = 'finscholar';
+
 /** Basic view class for all view objects. */
 class BasicView {
-  constructor() {}
+  constructor() {
+    /** @private @type {string} */
+    this.pageTitle_ = DEFAULT_PAGE_TITLE;
+    /** @private @type {?googSoy.data.SanitizedHtml} */
+    this.currentContent_ = null;
+  }
 
   /**
-   * Renders a college list view to the container.
-   * @param {!Element} container The HTML container to load the view.
+   * Returns the current page's title.
+   * @return {string} Title.
    */
-  async renderView(container) {}
+  getPageTitle() {
+    return this.pageTitle_;
+  }
+
+  /**
+   * @param {string} title
+   */
+  setPageTitle(title) {
+    this.pageTitle_ = title;
+  }
+
+  /**
+   * Returns the main content of the page and null if blank.
+   * @return {?googSoy.data.SanitizedHtml}
+   */
+  getCurrentContent() {
+    return this.currentContent_;
+  }
+
+  /**
+   * @param {?googSoy.data.SanitizedHtml} currentContent
+   */
+  setCurrentContent(currentContent) {
+    this.currentContent_ = currentContent;
+  }
+
+  /**
+   * Helper function for resetting and updating the whole page.
+   */
+  resetAndUpdate() {
+    googDom.getDocument().documentElement.innerHTML =
+        root(/** @type {!root.Params} */ (
+            {pageTitle: this.pageTitle_, content: this.currentContent_}));
+  }
+
+  /**
+   * Public method for updating the current view.
+   */
+  async renderView() {}
 }
 
-exports = {BasicView}
+exports = {BasicView};

--- a/src/main/webapp/js/basicview/basicview.soy
+++ b/src/main/webapp/js/basicview/basicview.soy
@@ -1,0 +1,42 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+{namespace basicview.templates}
+{alias finscholar.navbar.templates as Navbar}
+
+{template .root}
+  {@param pageTitle: string}
+  {@param content: html}
+  <!doctype html>
+  <html>
+    <head>
+      <meta charset="UTF-8">
+      <link rel="stylesheet"
+          href="https://fonts.googleapis.com/icon?family=Material+Icons">
+      <link rel="stylesheet"
+          href="https://code.getmdl.io/1.3.0/material.indigo-red.min.css">
+      <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+      <script type="module" src="js/bundle.min.js"></script>
+      <title>{$pageTitle}</title>
+    </head>
+    <body>
+      {call Navbar.navbar}{/call}
+      <div class="mdl-card__supporting-text">
+        <h1>FINSCHOLAR</h1>
+      </div>
+      <main id="content">
+        {$content}
+      </main>
+    </body>
+  </html>
+{/template}

--- a/src/main/webapp/js/datahandlers/collegepagedatahandler.js
+++ b/src/main/webapp/js/datahandlers/collegepagedatahandler.js
@@ -18,8 +18,8 @@
  */
 
 goog.module('datahandlers.collegepage');
+
 const {collegepage} = goog.require('finscholar.collegepageview.templates');
-const {ErrorData, ErrorPageView} = goog.require('finscholar.errorpageview');
 
 /** This constant is the endpoint to send a fetch request to. */
 const COLLEGE_SERVLET_ENDPOINT = '/college-data';
@@ -36,17 +36,17 @@ const ACTION_SERVER_ERROR = 'The database failed to retrieve the college. \
 
 /**
  * @typedef {{
- *   schoolName: !string,
- *   institutionType: !string,
- *   acceptanceRate: !number,
- *   averageACTScore: !number,
- *   totalCostAttendance: !number,
- *   netCostForFirstQuintile: !number,
- *   netCostForSecondQuintile: !number,
- *   netCostForThirdQuintile: !number,
- *   netCostForFourthQuintile: !number,
- *   netCostForFifthQuintile: !number,
- *   cumulativeMedianDebt: !number
+ *   schoolName: string,
+ *   institutionType: string,
+ *   acceptanceRate: number,
+ *   averageACTScore: number,
+ *   totalCostAttendance: number,
+ *   netCostForFirstQuintile: number,
+ *   netCostForSecondQuintile: number,
+ *   netCostForThirdQuintile: number,
+ *   netCostForFourthQuintile: number,
+ *   netCostForFifthQuintile: number,
+ *   cumulativeMedianDebt: number
  * }}
  */
 let CollegeObject;
@@ -101,29 +101,32 @@ const loadCollegeData = async (element) => {
 
   try {
     json = await loadCollegeJson_();
-  } catch (err) {
+  } catch (error) {
     loadErrorPage_(
-        element, OCCURRENCE_JSON_UNDEFINED, ACTION_JSON_UNDEFINED, err);
+        element, OCCURRENCE_JSON_UNDEFINED, ACTION_JSON_UNDEFINED, error);
   }
 
   try {
     const data = await convertFromJsonToTemplate_(json);
     const html = collegepage(data);
     element.innerHTML = html;
-  } catch (err) {
-    loadErrorPage_(element, OCCURRENCE_SERVER_ERROR, ACTION_SERVER_ERROR, err);
+  } catch (error) {
+    loadErrorPage_(
+        element, OCCURRENCE_SERVER_ERROR, ACTION_SERVER_ERROR, error);
   }
 };
 
 /**
  * Loads the error page.
- * @param
  * @private
  */
 const loadErrorPage_ = (element, occurrence, action, error) => {
-  const errorPage = new ErrorPageView(/** @type {!ErrorData|undefined} */ (
-      {occurrence: occurrence, action: action, errorMessage: err.toString()}));
-  errorPage.renderView(element);
+  //  const errorPage = new ErrorPageView(/** @type {!ErrorData|undefined} */ ({
+  //    occurrence: occurrence,
+  //    action: action,
+  //    errorMessage: error.toString()
+  //  }));
+  //  errorPage.renderView(element);
 };
 
 exports = {loadCollegeData};

--- a/src/main/webapp/js/datahandlers/collegepagedatahandler.js
+++ b/src/main/webapp/js/datahandlers/collegepagedatahandler.js
@@ -12,47 +12,67 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/** @fileoverview This class handles populating the college page view with data from the servlet. */
+/**
+ * @fileoverview This class handles populating the college page view with data
+ * from the servlet.
+ */
 
 goog.module('datahandlers.collegepage');
 const {collegepage} = goog.require('finscholar.collegepageview.templates');
-const {ErrorPageView} = goog.require('finscholar.errorpageview');
+const {ErrorData, ErrorPageView} = goog.require('finscholar.errorpageview');
 
 /** This constant is the endpoint to send a fetch request to. */
 const COLLEGE_SERVLET_ENDPOINT = '/college-data';
 const ERROR_MESSAGE_JSON_UNDEFINED = 'JSON object undefined.';
-const OCCURRENCE_JSON_UNDEFINED = 'A network error has occurred. Failed to load college data.';
-const ACTION_JSON_UNDEFINED = 'Please reload the page or select a different college.';
-const OCCURRENCE_SERVER_ERROR = 'A database error occurred. Failed to render college data.';
+const OCCURRENCE_JSON_UNDEFINED =
+    'A network error has occurred. Failed to load college data.';
+const ACTION_JSON_UNDEFINED =
+    'Please reload the page or select a different college.';
+const OCCURRENCE_SERVER_ERROR =
+    'A database error occurred. Failed to render college data.';
 const ACTION_SERVER_ERROR = 'The database failed to retrieve the college. \
       This college may not exist. Please reload the page or select a different college.';
 
 
 /**
- * This method converts from JSON to a JS object map, 
+ * @typedef {{
+ *   schoolName: !string,
+ *   institutionType: !string,
+ *   acceptanceRate: !number,
+ *   averageACTScore: !number,
+ *   totalCostAttendance: !number,
+ *   netCostForFirstQuintile: !number,
+ *   netCostForSecondQuintile: !number,
+ *   netCostForThirdQuintile: !number,
+ *   netCostForFourthQuintile: !number,
+ *   netCostForFifthQuintile: !number,
+ *   cumulativeMedianDebt: !number
+ * }}
+ */
+let CollegeObject;
+
+/**
+ * This method converts from JSON to a JS object map,
  *  which will be used to populate the college page soy template.
- * @param {*} json - The JSON object to be converted.
- * @return {Object} - The object map representing a college's data.
+ * @param {!CollegeObject|undefined} json - The JSON object to be converted.
+ * @return {!Promise<!CollegeObject>} - The object map representing a college's data.
  * @private
  */
 const convertFromJsonToTemplate_ = async (json) => {
-  if(json !== undefined) {
-    // Unfortunately, JSON bracket notation requires double quotes.
-    // Can't use dot notation here since there is no way to verify
-    //   that json is indeed a JSON object. (Per the Closure compiler).
-    return {
-      schoolName : json["schoolName"],
-      institutionType: json["institutionType"],
-      acceptanceRate: json["acceptanceRate"],
-      averageACTScore: json["averageACTScore"],
-      totalCostAttendance: json["totalCostAttendance"],
-      netCostForFirstQuintile: json["netCostForFirstQuintile"],
-      netCostForSecondQuintile: json["netCostForSecondQuintile"],
-      netCostForThirdQuintile: json["netCostForThirdQuintile"],
-      netCostForFourthQuintile: json["netCostForFourthQuintile"],
-      netCostForFifthQuintile: json["netCostForFifthQuintile"],
-      cumulativeMedianDebt: json["cumulativeMedianDebt"]
-    };
+  if (json !== undefined) {
+    return /** @type {!CollegeObject} */ ({
+      schoolName: json['schoolName'],
+      institutionType: json['institutionType'],
+      acceptanceRate: json['acceptanceRate'],
+      averageACTScore: json['averageACTScore'],
+      totalCostAttendance: json['totalCostAttendance'],
+      netCostForFirstQuintile: json['netCostForFirstQuintile'],
+      netCostForSecondQuintile: json['netCostForSecondQuintile'],
+      netCostForThirdQuintile: json['netCostForThirdQuintile'],
+      netCostForFourthQuintile: json['netCostForFourthQuintile'],
+      netCostForFifthQuintile: json['netCostForFifthQuintile'],
+      cumulativeMedianDebt: json['cumulativeMedianDebt']
+    });
   } else {
     throw new Error(ERROR_MESSAGE_JSON_UNDEFINED);
   }
@@ -60,13 +80,13 @@ const convertFromJsonToTemplate_ = async (json) => {
 
 /**
  * Fetch request to the data servlet and return the JSON response.
- * @return {*} - The JSON response.
+ * @return {!Promise<!CollegeObject|undefined>} - The JSON response.
  * @private
  */
 const loadCollegeJson_ = async () => {
   const response = await fetch(COLLEGE_SERVLET_ENDPOINT);
   if (response.ok) {
-    return await response.json();
+    return /** @type {!CollegeObject|undefined} */ (await response.json());
   } else {
     throw new Error(`${response.statusText}. Status: ${response.status}.`);
   }
@@ -74,34 +94,36 @@ const loadCollegeJson_ = async () => {
 
 /**
  * Render the soy template's html by attaching it to the desired DOM element.
- * @param {Element} element - The DOM element where the template should be rendered to.
+ * @param {!Element} element - The DOM element where the template should be rendered to.
  */
 const loadCollegeData = async (element) => {
   let json = undefined;
 
   try {
     json = await loadCollegeJson_();
-  } catch(err) {
-    loadErrorPage_(element, OCCURRENCE_JSON_UNDEFINED, ACTION_JSON_UNDEFINED, err);
+  } catch (err) {
+    loadErrorPage_(
+        element, OCCURRENCE_JSON_UNDEFINED, ACTION_JSON_UNDEFINED, err);
   }
 
   try {
     const data = await convertFromJsonToTemplate_(json);
     const html = collegepage(data);
     element.innerHTML = html;
-  } catch(err) {
+  } catch (err) {
     loadErrorPage_(element, OCCURRENCE_SERVER_ERROR, ACTION_SERVER_ERROR, err);
-  }  
-}
+  }
+};
 
 /**
  * Loads the error page.
- * @param 
+ * @param
  * @private
  */
-const loadErrorPage_ = (element,  occurrence, action, error) => { 
-  const errorPage = new ErrorPageView();
-  errorPage.renderErrorPage(element, occurrence, action, error.toString());
-}
+const loadErrorPage_ = (element, occurrence, action, error) => {
+  const errorPage = new ErrorPageView(/** @type {!ErrorData|undefined} */ (
+      {occurrence: occurrence, action: action, errorMessage: err.toString()}));
+  errorPage.renderView(element);
+};
 
 exports = {loadCollegeData};

--- a/src/main/webapp/js/datahandlers/collegepagedatahandler.js
+++ b/src/main/webapp/js/datahandlers/collegepagedatahandler.js
@@ -30,8 +30,9 @@ const ACTION_JSON_UNDEFINED =
     'Please reload the page or select a different college.';
 const OCCURRENCE_SERVER_ERROR =
     'A database error occurred. Failed to render college data.';
-const ACTION_SERVER_ERROR = 'The database failed to retrieve the college. \
-      This college may not exist. Please reload the page or select a different college.';
+const ACTION_SERVER_ERROR =
+    'The database failed to retrieve the college. This college may not ' +
+    'exist. Please reload the page or select a different college.';
 
 
 /**

--- a/src/main/webapp/js/datahandlers/scholarshipdatahandler.js
+++ b/src/main/webapp/js/datahandlers/scholarshipdatahandler.js
@@ -19,21 +19,21 @@ const {Map: SoyMap} = goog.require('soy.map');
 const {addSpaceToCamelCase} = goog.require('datahandlers.utils');
 
 const NA = 'N/A';
-const REQUIREMENTS = ['academicRequirements', 
-                      'ethnicityRaceRequirements', 
-                      'financialRequirements', 
-                      'genderRequirements',
-                      'locationRequirements',
-                      'nationalOriginRequirements',
-                      'otherRequirements'];
+const REQUIREMENTS = [
+  'academicRequirements', 'ethnicityRaceRequirements', 'financialRequirements',
+  'genderRequirements', 'locationRequirements', 'nationalOriginRequirements',
+  'otherRequirements'
+];
 const SEPARATOR = ', ';
 const SCHOLARSHIP_ENDPOINT = '/scholarship-data';
 
-/** This class loads scholarship data from the backend and formats it for soy templates.  */
+/**
+ * This class loads scholarship data from the backend and formats it for soy
+ * templates.
+ */
 class ScholarshipDataHandler {
-
   /**
-   * This method converts from scholarship JSON object to a JS object map, 
+   * This method converts from scholarship JSON object to a JS object map,
    *  which will be used to render the scholarship page soy template.
    * @param {*} data - The JSON object to be converted.
    * @return {Object} - The object map representing a scholarship's data.
@@ -41,11 +41,13 @@ class ScholarshipDataHandler {
    */
   async convertFromJsonToTemplate_(data) {
     const requirementsMap = new Map();
-                           
+
     let requirement = undefined;
     for (requirement of REQUIREMENTS) {
       if (REQUIREMENTS[requirement] != undefined) {
-        requirementsMap.set(addSpaceToCamelCase(requirement), REQUIREMENTS[requirement].join(SEPARATOR));
+        requirementsMap.set(
+            addSpaceToCamelCase(requirement),
+            REQUIREMENTS[requirement].join(SEPARATOR));
       } else {
         requirementsMap.set(addSpaceToCamelCase(requirement), NA);
       }
@@ -60,10 +62,10 @@ class ScholarshipDataHandler {
 
     return {
       generalInfo: {
-        scholarshipName: data['scholarshipName'], 
-        scholarshipUUID: data['scholarshipUUID'], 
+        scholarshipName: data['scholarshipName'],
+        scholarshipUUID: data['scholarshipUUID'],
         schoolsList: data['schoolsList'],
-        introduction: data['introduction'], 
+        introduction: data['introduction'],
         URL: data['URL'],
       },
       requirements: requirementsMap,
@@ -72,13 +74,13 @@ class ScholarshipDataHandler {
         applicationProcess: data['applicationProcess'],
         isRenewable: data['isRenewable'],
         numberOfYears: data['numberOfYears'],
-      }, 
+      },
     };
   };
 
   /**
    * Fetch the scholarship data with the specified uuid and format it.
-   * @param {string} id The uuid of the scholarship data.
+   * @param {number} id The uuid of the scholarship data.
    * @return The formatted scholarship JS object map.
    */
   async fetchAndFormatSingleScholarshipData(id) {
@@ -93,18 +95,18 @@ class ScholarshipDataHandler {
       return this.convertFromJsonToTemplate_(data[id]);
     } catch (e) {
       console.log(e);
-      throw(`Failed to fetch scholarship object ${e}`);
+      throw (`Failed to fetch scholarship object ${e}`);
     }
   }
 
   /**
    * Fetch request to the data servlet and return the JSON response.
-   * @param {string} id The uuid of the schedule.
+   * @param {number} id The uuid of the schedule.
    * @return {*} - The JSON response.
    * @private
    */
   async fetchScholarshipJson_(id) {
-    const response = await fetch(SCHOLARSHIP_ENDPOINT, {'id': id });
+    const response = await fetch(SCHOLARSHIP_ENDPOINT, {'id': id});
     let data = undefined;
     if (response.ok) {
       try {

--- a/src/main/webapp/js/finscholar/appstate/appstate.js
+++ b/src/main/webapp/js/finscholar/appstate/appstate.js
@@ -1,0 +1,64 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** @fileoverview App state manager. */
+
+goog.module('finscholar.appstate');
+
+const {HomePageController} = goog.require('finscholar.homepagecontroller');
+const {NavBar} = goog.require('finscholar.navbar');
+const {navbarViewFactory} = goog.require('finscholar.viewfactory');
+
+
+/** Class that keeps track of the app's state. */
+class AppState {
+  constructor() {
+    if (AppState.instance_) {
+      return AppState.instance_;
+    }
+
+    /** @private @const {!AppState} */
+    AppState.instance_ = this;
+
+    this.currentView_ = new HomePageController();
+    this.currentView_.renderView();
+    /** @private @type {!NavBar} Initializes the code for the nav bar. */
+    this.navbarInstance_ = new NavBar();
+    this.navbarInstance_.registerListener(this.navbarUpdate.bind(this));
+  }
+
+  /**
+   * Returns the current app state instance.
+   * @return {!AppState}
+   */
+  static getInstance() {
+    if (AppState.instance_) {
+      return AppState.instance_;
+    }
+    return new AppState();
+  }
+
+  /**
+   * Handles updates from the nav bar.
+   * @param {number} index The button mapped to the view that the user selected.
+   */
+  navbarUpdate(index) {
+    this.currentView_ = navbarViewFactory(index);
+    this.currentView_.renderView();
+    this.navbarInstance_ = new NavBar();
+    this.navbarInstance_.registerListener(this.navbarUpdate.bind(this));
+  }
+}
+
+exports = {AppState};

--- a/src/main/webapp/js/finscholar/collegelistview/collegelistview.js
+++ b/src/main/webapp/js/finscholar/collegelistview/collegelistview.js
@@ -26,12 +26,12 @@ class CollegeListView extends BasicView {
 
   /**
    * Renders a college list view to the container.
-   * @param {!Element} container The HTML container to load the view.
    * @override
    */
-  async renderView(container) {
-    container.innerHTML = collegelist();
+  async renderView() {
+    super.setCurrentContent(collegelist());
+    super.resetAndUpdate();
   }
 }
 
-exports = {CollegeListView}
+exports = {CollegeListView};

--- a/src/main/webapp/js/finscholar/collegepageview/collegepageview.js
+++ b/src/main/webapp/js/finscholar/collegepageview/collegepageview.js
@@ -17,16 +17,23 @@
 goog.module('finscholar.collegepageview');
 
 const GoogDom = goog.require('goog.dom');
+const {BasicView} = goog.require('basicview');
 const {loadCollegeData} = goog.require('datahandlers.collegepage');
 
 /** Class for the college page view. */
-class CollegePageView {
-  constructor() {}
+class CollegePageView extends BasicView {
+  constructor() {
+    super();
+  }
 
-  /** Render the college page. */
+  /**
+   * Render the college page.
+   * @param {!Element} element
+   * @override
+   */
   async renderView(element) {
     await loadCollegeData(element);
-  };
+  }
 }
 
 exports = {CollegePageView};

--- a/src/main/webapp/js/finscholar/collegepageview/collegepageview.js
+++ b/src/main/webapp/js/finscholar/collegepageview/collegepageview.js
@@ -16,9 +16,7 @@
 
 goog.module('finscholar.collegepageview');
 
-const GoogDom = goog.require('goog.dom');
 const {BasicView} = goog.require('basicview');
-const {loadCollegeData} = goog.require('datahandlers.collegepage');
 
 /** Class for the college page view. */
 class CollegePageView extends BasicView {
@@ -28,11 +26,12 @@ class CollegePageView extends BasicView {
 
   /**
    * Render the college page.
-   * @param {!Element} element
    * @override
    */
-  async renderView(element) {
-    await loadCollegeData(element);
+  async renderView() {
+    // TODO: refactor college data handler to return data here to pass up to
+    // setCurrentView.
+    //    await loadCollegeData(element);
   }
 }
 

--- a/src/main/webapp/js/finscholar/errorpageview/errorpageview.js
+++ b/src/main/webapp/js/finscholar/errorpageview/errorpageview.js
@@ -17,28 +17,47 @@
 goog.module('finscholar.errorpageview');
 
 const GoogDom = goog.require('goog.dom');
+const {BasicView} = goog.require('basicview');
 const {errorpage} = goog.require('finscholar.errorpageview.templates');
+/**
+ * @typedef {{
+ *   occurrence: string,
+ *   action: string,
+ *   errorMessage: string
+ * }}
+ */
+let ErrorData;
 
 /** Class for the error page view. */
-class ErrorPageView {
-  constructor() {}
+class ErrorPageView extends BasicView {
+  /**
+   * @param {!ErrorData=} data Object containing error info.
+   */
+  constructor(data) {
+    super();
+    /** @type {!ErrorData|undefined} */
+    this.data_ = data;
+  }
+
+  /**
+   * Updates the data object. Useful for running before rendering view.
+   * @param {!ErrorData} data New error info.
+   */
+  updateError(data) {
+    this.data_ = data;
+  }
 
   /**
    * Render the error page.
-   * @param {Element} element - The element to render the error page to.
-   * @param {string} newOccurrence - Message explaining what happened.
-   * @param {string} newAction - Action to be taken upon receiving the error message.
-   * @param {string} newErrorMessage - The error message that was thrown when the error occurred.
+   * @param {!Element} element - The element to render the error page to.
    */
-  async renderErrorPage(element, newOccurrence, newAction, newErrorMessage) {
-    const data = {
-      occurrence : newOccurrence,
-      action : newAction,
-      errorMessage : newErrorMessage
-    }
-    const html = errorpage(data);
+  async renderView(element) {
+    const html = errorpage(/** @type {!ErrorData} */ (this.data_));
     element.innerHTML = html;
-  };
+  }
 }
 
-exports = {ErrorPageView};
+exports = {
+  ErrorPageView,
+  ErrorData
+};

--- a/src/main/webapp/js/finscholar/errorpageview/errorpageview.js
+++ b/src/main/webapp/js/finscholar/errorpageview/errorpageview.js
@@ -16,7 +16,6 @@
 
 goog.module('finscholar.errorpageview');
 
-const GoogDom = goog.require('goog.dom');
 const {BasicView} = goog.require('basicview');
 const {errorpage} = goog.require('finscholar.errorpageview.templates');
 /**
@@ -35,7 +34,7 @@ class ErrorPageView extends BasicView {
    */
   constructor(data) {
     super();
-    /** @type {!ErrorData|undefined} */
+    /** @private @type {!ErrorData|undefined} */
     this.data_ = data;
   }
 
@@ -49,11 +48,11 @@ class ErrorPageView extends BasicView {
 
   /**
    * Render the error page.
-   * @param {!Element} element - The element to render the error page to.
    */
-  async renderView(element) {
+  async renderView() {
     const html = errorpage(/** @type {!ErrorData} */ (this.data_));
-    element.innerHTML = html;
+    super.setCurrentContent(html);
+    super.resetAndUpdate();
   }
 }
 

--- a/src/main/webapp/js/finscholar/homepagecontroller/homepagecontroller.js
+++ b/src/main/webapp/js/finscholar/homepagecontroller/homepagecontroller.js
@@ -16,9 +16,10 @@
 
 goog.module('finscholar.homepagecontroller');
 
+const {BasicView} = goog.require('basicview');
 const {CollegeListView} = goog.require('finscholar.collegelistview');
 const {CollegePageView} = goog.require('finscholar.collegepageview');
-const {ErrorPageView} = goog.require('finscholar.errorpageview');
+const {ErrorData, ErrorPageView} = goog.require('finscholar.errorpageview');
 const {PageController} = goog.require('pagecontroller');
 const {ScholarshipListView} = goog.require('finscholar.scholarshiplistview');
 const {ScholarshipPageView} = goog.require('finscholar.scholarshippageview');
@@ -29,7 +30,8 @@ const jsactionActionFlow = goog.require('jsaction.ActionFlow');
 const jsactionDispatcher = goog.require('jsaction.Dispatcher');
 const jsactionEventContract = goog.require('jsaction.EventContract');
 
-const TEST_ERR_INPUT1 = 'A network error has occurred. Failed to load college data.';
+const TEST_ERR_INPUT1 =
+    'A network error has occurred. Failed to load college data.';
 const TEST_ERR_INPUT2 = 'Please reload the page or select a different college.';
 const TEST_ERR_INPUT3 = 'Thanks!';
 
@@ -37,8 +39,7 @@ const TEST_ERR_INPUT3 = 'Thanks!';
  * Class for the home page controller.
  */
 class HomePageController extends PageController {
-
-  /** 
+  /**
    * @param {!Element} container The HTML div where the main frame is rendered.
    */
   constructor(container) {
@@ -53,23 +54,18 @@ class HomePageController extends PageController {
     this.dispatcher_ = new jsactionDispatcher();
 
     /** @private @const {!function(jsaction.ActionFlow): undefined} */
-    this.bindedNavbarOnclickHandler_ = this.handleNavbarOnclickEvent_.bind(this);
+    this.bindedNavbarOnclickHandler_ =
+        this.handleNavbarOnclickEvent_.bind(this);
 
-    /** @private {number} */
+    /** @private @type {number} */
     this.navbarPageIndex_ = 0;
 
-    /** @private @const 
-     * {!Array<CollegeListView, ScholarshipListView, 
-     *     CollegePageView, ScholarshipPageView, ErrorPageView>} 
-     */
+    /** @private @const {!Array<!BasicView>} */
     this.TEMPLATE_HANDLERS_ = [
-                               CollegeListView, 
-                               ScholarshipListView, 
-                               CollegePageView, 
-                               ScholarshipPageView, 
-                               ErrorPageView
-                               ];
-    
+      CollegeListView, ScholarshipListView, CollegePageView,
+      ScholarshipPageView, ErrorPageView
+    ];
+
     this.initJsaction_();
 
     this.container_.innerHTML = this.getContent_();
@@ -94,13 +90,13 @@ class HomePageController extends PageController {
     this.eventContract_.dispatchTo(
         this.dispatcher_.dispatch.bind(this.dispatcher_));
     this.dispatcher_.registerHandlers(
-      'homepagecontroller',  // the namespace
-      null,                  // handler object
-      {
-        // action map
-        'clickAction': this.bindedNavbarOnclickHandler_,
-        'doubleClickAction' : this.bindedNavbarOnclickHandler_,
-      });
+        'homepagecontroller',  // the namespace
+        null,                  // handler object
+        {
+          // action map
+          'clickAction': this.bindedNavbarOnclickHandler_,
+          'doubleClickAction': this.bindedNavbarOnclickHandler_,
+        });
   }
 
   /**
@@ -130,13 +126,17 @@ class HomePageController extends PageController {
   renderPage_() {
     // This if statement is temporarily added to enable showing the error page.
     if (this.navbarPageIndex_ == 4) {
-      this.TEMPLATE_HANDLERS_[this.navbarPageIndex_].renderView(this.subView_, 
-        TEST_ERR_INPUT1,
-        TEST_ERR_INPUT2,
-        TEST_ERR_INPUT3);
+      /** @type {!ErrorPageView} */
+      (new this.TEMPLATE_HANDLERS_[this.navbarPageIndex_](
+              /** @type {!ErrorData} */ ({
+                occurrence: TEST_ERR_INPUT1,
+                action: TEST_ERR_INPUT2,
+                errorMessage: TEST_ERR_INPUT3
+              })).renderView(this.subView_);
     } else {
       // In actual product we'll only have this line in this function.
-      (new this.TEMPLATE_HANDLERS_[this.navbarPageIndex_]).renderView(this.subView_);
+      (new this.TEMPLATE_HANDLERS_[this.navbarPageIndex_])
+          .renderView(this.subView_);
     }
   }
 }

--- a/src/main/webapp/js/finscholar/homepagecontroller/homepagecontroller.js
+++ b/src/main/webapp/js/finscholar/homepagecontroller/homepagecontroller.js
@@ -17,127 +17,24 @@
 goog.module('finscholar.homepagecontroller');
 
 const {BasicView} = goog.require('basicview');
-const {CollegeListView} = goog.require('finscholar.collegelistview');
-const {CollegePageView} = goog.require('finscholar.collegepageview');
-const {ErrorData, ErrorPageView} = goog.require('finscholar.errorpageview');
-const {PageController} = goog.require('pagecontroller');
-const {ScholarshipListView} = goog.require('finscholar.scholarshiplistview');
-const {ScholarshipPageView} = goog.require('finscholar.scholarshippageview');
 const {homepage} = goog.require('finscholar.homepagecontroller.templates');
-const googDom = goog.require('goog.dom');
-const googSoy = goog.require('goog.soy');
-const jsactionActionFlow = goog.require('jsaction.ActionFlow');
-const jsactionDispatcher = goog.require('jsaction.Dispatcher');
-const jsactionEventContract = goog.require('jsaction.EventContract');
 
-const TEST_ERR_INPUT1 =
-    'A network error has occurred. Failed to load college data.';
-const TEST_ERR_INPUT2 = 'Please reload the page or select a different college.';
-const TEST_ERR_INPUT3 = 'Thanks!';
 
 /**
  * Class for the home page controller.
  */
-class HomePageController extends PageController {
-  /**
-   * @param {!Element} container The HTML div where the main frame is rendered.
-   */
-  constructor(container) {
+class HomePageController extends BasicView {
+  constructor() {
     super();
-    /** @private @const {!Element} */
-    this.container_ = container;
-
-    /** @private @const {!jsactionEventContract} */
-    this.eventContract_ = new jsactionEventContract();
-
-    /** @private @const {!jsactionDispatcher} */
-    this.dispatcher_ = new jsactionDispatcher();
-
-    /** @private @const {!function(jsaction.ActionFlow): undefined} */
-    this.bindedNavbarOnclickHandler_ =
-        this.handleNavbarOnclickEvent_.bind(this);
-
-    /** @private @type {number} */
-    this.navbarPageIndex_ = 0;
-
-    /** @private @const {!Array<!BasicView>} */
-    this.TEMPLATE_HANDLERS_ = [
-      CollegeListView, ScholarshipListView, CollegePageView,
-      ScholarshipPageView, ErrorPageView
-    ];
-
-    this.initJsaction_();
-
-    this.container_.innerHTML = this.getContent_();
-
-    /** @private @const {!Element} subView_*/
-    this.subView_ = /** @type {!Element} */ (googDom.getElement('content'));
-
-    this.renderPage_();
   }
 
   /**
-   * Sets up the event handlers for elements in the main frame.
-   * @private
+   * Loads the home page view.
+   * @override
    */
-  initJsaction_() {
-    // Events will be handled for all elements under this container.
-    this.eventContract_.addContainer(
-        /** @type {!Element} */ (googDom.getElement('main')));
-    // Register the event types we care about.
-    this.eventContract_.addEvent('click');
-    this.eventContract_.addEvent('dblclick');
-    this.eventContract_.dispatchTo(
-        this.dispatcher_.dispatch.bind(this.dispatcher_));
-    this.dispatcher_.registerHandlers(
-        'homepagecontroller',  // the namespace
-        null,                  // handler object
-        {
-          // action map
-          'clickAction': this.bindedNavbarOnclickHandler_,
-          'doubleClickAction': this.bindedNavbarOnclickHandler_,
-        });
-  }
-
-  /**
-   * @return {!googSoy.data.SanitizedHtml} The rendered HTML of the common framework.
-   * @private
-   */
-  getContent_() {
-    return homepage();
-  }
-
-  /**
-   * Handles click and double click events on navbar.
-   * @param {!jsactionActionFlow} flow Contains the data related to the action.
-   *     and more. See actionflow.js.
-   * @private
-   */
-  handleNavbarOnclickEvent_(flow) {
-    const index = flow.node().getAttribute('index');
-    this.navbarPageIndex_ = parseInt(index, 10);
-    this.renderPage_();
-  }
-
-  /**
-   * Render the div with id 'content' based on the click event navber buttons.
-   * @private
-   */
-  renderPage_() {
-    // This if statement is temporarily added to enable showing the error page.
-    if (this.navbarPageIndex_ == 4) {
-      /** @type {!ErrorPageView} */
-      (new this.TEMPLATE_HANDLERS_[this.navbarPageIndex_](
-              /** @type {!ErrorData} */ ({
-                occurrence: TEST_ERR_INPUT1,
-                action: TEST_ERR_INPUT2,
-                errorMessage: TEST_ERR_INPUT3
-              })).renderView(this.subView_);
-    } else {
-      // In actual product we'll only have this line in this function.
-      (new this.TEMPLATE_HANDLERS_[this.navbarPageIndex_])
-          .renderView(this.subView_);
-    }
+  async renderView() {
+    super.setCurrentContent(homepage());
+    super.resetAndUpdate();
   }
 }
 

--- a/src/main/webapp/js/finscholar/homepagecontroller/homepagecontroller.soy
+++ b/src/main/webapp/js/finscholar/homepagecontroller/homepagecontroller.soy
@@ -11,40 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 {namespace finscholar.homepagecontroller.templates}
 {template .homepage}
-  <div class="mdl-card__supporting-text">
-    <h4>FINSCHOLAR</h4>
-    <p>This is the home page for our website :)</p>
-  </div>
-  <div id="temp-navbar">
-    <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect 
-        mdl-button--accent" index="0" 
-        jsaction="homepagecontroller.clickAction;dblclick:homepageController.doubleClickAction">
-      College List
-    </button>
-    <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect
-        mdl-button--accent" index="1" 
-        jsaction="homepagecontroller.clickAction;dblclick:homepageController.doubleClickAction">
-      Scholarship List
-    </button>
-    <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect 
-        mdl-button--accent" index="2" 
-        jsaction="homepagecontroller.clickAction;dblclick:homepageController.doubleClickAction">
-      Single College
-    </button>
-    <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect 
-        mdl-button--accent" index="3" 
-        jsaction="homepagecontroller.clickAction;dblclick:homepageController.doubleClickAction">
-      Single Scholarship
-    </button>
-    <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect 
-        mdl-button--accent" index="4" 
-        jsaction="homepagecontroller.clickAction;dblclick:homepageController.doubleClickAction">
-      Error Page
-    </button>
-  </div>
-  <div id="content">
-  </div>
+  <p>This is the home page for our website :)</p>
 {/template}

--- a/src/main/webapp/js/finscholar/init.js
+++ b/src/main/webapp/js/finscholar/init.js
@@ -16,12 +16,14 @@
 
 goog.module('finscholar');
 
-const googDom = goog.require('goog.dom');
-const {HomePageController} = goog.require('finscholar.homepagecontroller');
+const {AppState} = goog.require('finscholar.appstate');
 
+/**
+ * Main entry point for the app.
+ * @return {!AppState}
+ */
 const init = () => {
-  const homeController = new HomePageController(
-      /** @type {!Element} */ (googDom.getElement('main')));
+  return new AppState();
 };
 
 goog.exportSymbol('onload', init);

--- a/src/main/webapp/js/finscholar/init.js
+++ b/src/main/webapp/js/finscholar/init.js
@@ -21,7 +21,7 @@ const {HomePageController} = goog.require('finscholar.homepagecontroller');
 
 const init = () => {
   const homeController = new HomePageController(
-        /** @type {!Element} */ (googDom.getElement('main')));
+      /** @type {!Element} */ (googDom.getElement('main')));
 };
 
 goog.exportSymbol('onload', init);

--- a/src/main/webapp/js/finscholar/navbar/navbar.js
+++ b/src/main/webapp/js/finscholar/navbar/navbar.js
@@ -1,0 +1,96 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** @fileoverview Class for navbar. */
+
+goog.module('finscholar.navbar');
+
+const JsactionActionFlow = goog.require('jsaction.ActionFlow');
+const JsactionDispatcher = goog.require('jsaction.Dispatcher');
+const JsactionEventContract = goog.require('jsaction.EventContract');
+const googDom = goog.require('goog.dom');
+
+
+/**
+ * Class for the navbar.
+ */
+class NavBar {
+  constructor() {
+    /** @private @const {!JsactionEventContract} */
+    this.eventContract_ = new JsactionEventContract();
+
+    /** @private @const {!JsactionDispatcher} */
+    this.dispatcher_ = new JsactionDispatcher();
+
+    /** @private @type {!Array<function(number): undefined>} */
+    this.listeners_ = [];
+
+    /** @private @const {function(!JsactionActionFlow): undefined} */
+    this.bindedNavbarOnclickHandler_ =
+        this.handleNavbarOnclickEvent_.bind(this);
+
+    /** @private @type {number} */
+    this.navbarPageIndex_ = 0;
+
+    this.initJsaction_();
+  }
+
+  /**
+   * Sets up the event handlers for elements in the navbar.
+   * @private
+   */
+  initJsaction_() {
+    // Events will be handled for all elements under this container.
+    this.eventContract_.addContainer(
+        /** @type {!Element} */ (googDom.getElement('navbar')));
+    // Register the event types we care about.
+    this.eventContract_.addEvent('click');
+    this.eventContract_.addEvent('dblclick');
+    this.eventContract_.dispatchTo(
+        this.dispatcher_.dispatch.bind(this.dispatcher_));
+    this.dispatcher_.registerHandlers(
+        'navbar',  // the namespace
+        null,      // handler object
+        {
+          // action map
+          'clickAction': this.bindedNavbarOnclickHandler_,
+          'doubleClickAction': this.bindedNavbarOnclickHandler_,
+        });
+  }
+
+  /**
+   * Handles click and double click events on navbar.
+   * @param {!JsactionActionFlow} flow Contains the data related to the action.
+   *     and more. See actionflow.js.
+   * @private
+   */
+  handleNavbarOnclickEvent_(flow) {
+    console.log('testing firing of handler.');
+    const index = flow.node().getAttribute('index');
+    this.navbarPageIndex_ = parseInt(index, 10);
+    this.listeners_.forEach((listener) => {
+      listener(this.navbarPageIndex_);
+    });
+  }
+
+  /**
+   * Takes an event to update with navbar updates.
+   * @param {function(number): undefined} listener
+   */
+  registerListener(listener) {
+    this.listeners_.push(listener);
+  }
+}
+
+exports = {NavBar};

--- a/src/main/webapp/js/finscholar/navbar/navbar.soy
+++ b/src/main/webapp/js/finscholar/navbar/navbar.soy
@@ -29,4 +29,5 @@
         jsaction="navbar.clickAction;dblclick:navbar.doubleClickAction">
       Scholarship List
     </button>
+  </nav>
 {/template}

--- a/src/main/webapp/js/finscholar/navbar/navbar.soy
+++ b/src/main/webapp/js/finscholar/navbar/navbar.soy
@@ -16,28 +16,17 @@
   <nav id="navbar">
     <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect 
         mdl-button--accent" index="0" 
-        jsaction="navbar.clickAction;dblclick:homepageController.doubleClickAction">
-      College List
+        jsaction="navbar.clickAction;dblclick:navbar.doubleClickAction">
+      Home
     </button>
     <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect
         mdl-button--accent" index="1" 
-        jsaction="navbar.clickAction;dblclick:homepageController.doubleClickAction">
-      Scholarship List
+        jsaction="navbar.clickAction;dblclick:navbar.doubleClickAction">
+      College List
     </button>
     <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect 
         mdl-button--accent" index="2" 
-        jsaction="navbar.clickAction;dblclick:homepageController.doubleClickAction">
-      Single College
+        jsaction="navbar.clickAction;dblclick:navbar.doubleClickAction">
+      Scholarship List
     </button>
-    <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect 
-        mdl-button--accent" index="3" 
-        jsaction="navbar.clickAction;dblclick:homepageController.doubleClickAction">
-      Single Scholarship
-    </button>
-    <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect 
-        mdl-button--accent" index="4" 
-        jsaction="navbar.clickAction;dblclick:homepageController.doubleClickAction">
-      Error Page
-    </button>
-  </nav>
 {/template}

--- a/src/main/webapp/js/finscholar/navbar/navbar.soy
+++ b/src/main/webapp/js/finscholar/navbar/navbar.soy
@@ -1,0 +1,43 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+{namespace finscholar.navbar.templates}
+{template .navbar}
+  <nav id="navbar">
+    <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect 
+        mdl-button--accent" index="0" 
+        jsaction="navbar.clickAction;dblclick:homepageController.doubleClickAction">
+      College List
+    </button>
+    <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect
+        mdl-button--accent" index="1" 
+        jsaction="navbar.clickAction;dblclick:homepageController.doubleClickAction">
+      Scholarship List
+    </button>
+    <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect 
+        mdl-button--accent" index="2" 
+        jsaction="navbar.clickAction;dblclick:homepageController.doubleClickAction">
+      Single College
+    </button>
+    <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect 
+        mdl-button--accent" index="3" 
+        jsaction="navbar.clickAction;dblclick:homepageController.doubleClickAction">
+      Single Scholarship
+    </button>
+    <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect 
+        mdl-button--accent" index="4" 
+        jsaction="navbar.clickAction;dblclick:homepageController.doubleClickAction">
+      Error Page
+    </button>
+  </nav>
+{/template}

--- a/src/main/webapp/js/finscholar/scholarshiplistview/scholarshiplistview.js
+++ b/src/main/webapp/js/finscholar/scholarshiplistview/scholarshiplistview.js
@@ -29,11 +29,11 @@ class ScholarshipListView extends BasicView {
 
   /**
    * Renders a scholarship list view to the container.
-   * @param {!Element} container The HTML container to load the view.
    * @override
    */
-  async renderView(container) {
-    container.innerHTML = scholarshiplist();
+  async renderView() {
+    super.setCurrentContent(scholarshiplist());
+    super.resetAndUpdate();
   }
 }
 

--- a/src/main/webapp/js/finscholar/scholarshiplistview/scholarshiplistview.js
+++ b/src/main/webapp/js/finscholar/scholarshiplistview/scholarshiplistview.js
@@ -15,20 +15,24 @@
 /** @fileoverview The mini controller for scholarship list view. */
 
 goog.module('finscholar.scholarshiplistview');
+
+const {BasicView} = goog.require('basicview');
 const {scholarshiplist} = goog.require('finscholar.scholarshiplistview.templates');
 
 /** The mini controller for scholarship list view. */
-class ScholarshipListView {
-  
+class ScholarshipListView extends BasicView {
   constructor() {
-    // TODO: In MVP, we'll add member variables such as pages, the array of scholarship etc.
+    super();
+    // TODO: In MVP, we'll add member variables such as pages, the array of
+    // scholarship etc.
   }
 
   /**
    * Renders a scholarship list view to the container.
    * @param {!Element} container The HTML container to load the view.
+   * @override
    */
-  renderView(container) {
+  async renderView(container) {
     container.innerHTML = scholarshiplist();
   }
 }

--- a/src/main/webapp/js/finscholar/scholarshippageview/scholarshippageview.js
+++ b/src/main/webapp/js/finscholar/scholarshippageview/scholarshippageview.js
@@ -17,21 +17,16 @@
 goog.module('finscholar.scholarshippageview');
 
 const GoogDom = goog.require('goog.dom');
+const {BasicView} = goog.require('basicview');
 const {scholarshippage} = goog.require('example.templates.scholarshippageviews');
 const {ScholarshipDataHandler} = goog.require('datahandlers.scholarshipdatahandler');
 
-/**
- * Class for scholarship page view.
- * @public
- */
-class ScholarshipPageView {
-
-  /**
-   * @constructor
-   */
+/** Class for scholarship page view. */
+class ScholarshipPageView extends BasicView {
   constructor() {
-    /** 
-     * @private @const {!ScholarshipDataHandler} dataHandler_ 
+    super();
+    /**
+     * @private @const {!ScholarshipDataHandler} dataHandler_
      * The object fetches and formats scholarship data.
      */
     this.dataHandler_ = new ScholarshipDataHandler();
@@ -39,29 +34,32 @@ class ScholarshipPageView {
 
   /**
    * Render the scholarship page.
-   * @public
    * @param {!Element} container - The DOM element for single scholarship page.
+   * @override
    */
-  async renderScholarship(container) {
-    // In the prototype, the id is set to 0 by default. Later we'll pass in id as parameter.
+  async renderView(container) {
+    // In the prototype, the id is set to 0 by default. Later we'll pass in id
+    // as parameter.
     const id = 0;
     let scholarshipData = undefined;
     try {
-      scholarshipData = await this.dataHandler_.fetchAndFormatSingleScholarshipData(id);
+      scholarshipData =
+          await this.dataHandler_.fetchAndFormatSingleScholarshipData(id);
     } catch (e) {
       console.log(e);
-      // Throws the error to the caller, and the caller will render an error page instead.
+      // Throws the error to the caller, and the caller will render an error
+      // page instead.
       throw new Error(`Cannot get data for scholarship ${id}, message: ${e}`);
     }
     try {
-      container.innerHTML = scholarshippage({scholarship: scholarshipData});      
-    } catch(e) {
+      container.innerHTML = scholarshippage({scholarship: scholarshipData});
+    } catch (e) {
       console.log(e);
-      // Throws the error to the caller, and the caller will render an error page instead.
+      // Throws the error to the caller, and the caller will render an error
+      // page instead.
       throw new Error(`Failed to generate html: ${e}`);
     }
   }
 }
 
 exports = {ScholarshipPageView};
-

--- a/src/main/webapp/js/finscholar/scholarshippageview/scholarshippageview.js
+++ b/src/main/webapp/js/finscholar/scholarshippageview/scholarshippageview.js
@@ -16,10 +16,10 @@
 
 goog.module('finscholar.scholarshippageview');
 
-const GoogDom = goog.require('goog.dom');
 const {BasicView} = goog.require('basicview');
-const {scholarshippage} = goog.require('example.templates.scholarshippageviews');
 const {ScholarshipDataHandler} = goog.require('datahandlers.scholarshipdatahandler');
+const {scholarshippage} = goog.require('example.templates.scholarshippageviews');
+
 
 /** Class for scholarship page view. */
 class ScholarshipPageView extends BasicView {
@@ -34,10 +34,9 @@ class ScholarshipPageView extends BasicView {
 
   /**
    * Render the scholarship page.
-   * @param {!Element} container - The DOM element for single scholarship page.
    * @override
    */
-  async renderView(container) {
+  async renderView() {
     // In the prototype, the id is set to 0 by default. Later we'll pass in id
     // as parameter.
     const id = 0;
@@ -52,7 +51,8 @@ class ScholarshipPageView extends BasicView {
       throw new Error(`Cannot get data for scholarship ${id}, message: ${e}`);
     }
     try {
-      container.innerHTML = scholarshippage({scholarship: scholarshipData});
+      super.setCurrentContent(scholarshippage({scholarship: scholarshipData}));
+      super.resetAndUpdate();
     } catch (e) {
       console.log(e);
       // Throws the error to the caller, and the caller will render an error

--- a/src/main/webapp/js/finscholar/viewfactory/viewfactory.js
+++ b/src/main/webapp/js/finscholar/viewfactory/viewfactory.js
@@ -1,0 +1,53 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** @fileoverview Factory for all the views. */
+
+goog.module('finscholar.viewfactory');
+
+const {BasicView} = goog.require('basicview');
+const {CollegeListView} = goog.require('finscholar.collegelistview');
+const {HomePageController} = goog.require('finscholar.homepagecontroller');
+const {ScholarshipListView} = goog.require('finscholar.scholarshiplistview');
+const {ScholarshipPageView} = goog.require('finscholar.scholarshippageview');
+
+
+/**
+ * Factory for the navbar listviews.
+ * @param {number} index The index mapping to the tab.
+ * @return {!BasicView} Object with the view data.
+ */
+const navbarViewFactory = (index) => {
+  let view;
+  switch (index) {
+    case 0:
+      view = new CollegeListView();
+      break;
+    case 1:
+      view = new ScholarshipListView();
+      break;
+    case 2:
+      view = new HomePageController();
+      break;
+    case 3:
+      view = new ScholarshipPageView();
+      break;
+    default:
+      view = new HomePageController();
+      break;
+  }
+  return /** @type {!BasicView} */ (view);
+};
+
+exports = {navbarViewFactory};

--- a/src/main/webapp/js/finscholar/viewfactory/viewfactory.js
+++ b/src/main/webapp/js/finscholar/viewfactory/viewfactory.js
@@ -32,13 +32,13 @@ const navbarViewFactory = (index) => {
   let view;
   switch (index) {
     case 0:
-      view = new CollegeListView();
+      view = new HomePageController();
       break;
     case 1:
       view = new ScholarshipListView();
       break;
     case 2:
-      view = new HomePageController();
+      view = new ScholarshipListView();
       break;
     case 3:
       view = new ScholarshipPageView();

--- a/src/main/webapp/js/finscholar/viewfactory/viewfactory.js
+++ b/src/main/webapp/js/finscholar/viewfactory/viewfactory.js
@@ -17,7 +17,6 @@
 goog.module('finscholar.viewfactory');
 
 const {BasicView} = goog.require('basicview');
-const {CollegeListView} = goog.require('finscholar.collegelistview');
 const {HomePageController} = goog.require('finscholar.homepagecontroller');
 const {ScholarshipListView} = goog.require('finscholar.scholarshiplistview');
 const {ScholarshipPageView} = goog.require('finscholar.scholarshippageview');


### PR DESCRIPTION
This pull request does a few things (I can break apart/refactor code to work with existing code), and is based off of the prototype branch.

- Adds initial plumbing for keeping track of the app's state. It currently doesn't actually record the context, but the support is there now for implementing things like fake back buttons.
- Soy templates now render on the whole page via the `BasicView` class. This allows us to control things like the title via a template. Additionally, we can always add more methods to the `BasicView` class to get more states of the app, such as the `content` element that we have been rendering to currently.
- The home page is now a sub view. Meaning that the app renders the initial template and then inserts the content from the home page into the content element.
- Separates the nav bar into its own sub-template and is called from the new skeleton initial page template.
- Adds more type annotations to variables. This is primarily to address all the compiler warnings.

The good news is that all of the list views appear to be happening in the context of the content div that we have been using, so merging this may not be too painful.