### PR TITLE
Temporarily disable the single college view

### DIFF
--- a/src/main/webapp/js/finscholar/collegepageview/collegepageview.js
+++ b/src/main/webapp/js/finscholar/collegepageview/collegepageview.js
@@ -16,17 +16,23 @@
 
 goog.module('finscholar.collegepageview');
 
-const GoogDom = goog.require('goog.dom');
-const {loadCollegeData} = goog.require('datahandlers.collegepage');
+const {BasicView} = goog.require('basicview');
 
 /** Class for the college page view. */
-class CollegePageView {
-  constructor() {}
+class CollegePageView extends BasicView {
+  constructor() {
+    super();
+  }
 
-  /** Render the college page. */
-  async renderView(element) {
-    await loadCollegeData(element);
-  };
+  /**
+   * Render the college page.
+   * @override
+   */
+  async renderView() {
+    // TODO: refactor college data handler to return data here to pass up to
+    // setCurrentView.
+    //    await loadCollegeData(element);
+  }
 }
 
 exports = {CollegePageView};


### PR DESCRIPTION
We plan to rewrite the college data handler, so disabled it from loading by commenting it out.