### PR TITLE
Refactor the homepage view to use the new BasicView super class

### DIFF
--- a/src/main/webapp/js/finscholar/homepagecontroller/homepagecontroller.js
+++ b/src/main/webapp/js/finscholar/homepagecontroller/homepagecontroller.js
@@ -16,128 +16,25 @@
 
 goog.module('finscholar.homepagecontroller');
 
-const {CollegeListView} = goog.require('finscholar.collegelistview');
-const {CollegePageView} = goog.require('finscholar.collegepageview');
-const {ErrorPageView} = goog.require('finscholar.errorpageview');
-const {PageController} = goog.require('pagecontroller');
-const {ScholarshipListView} = goog.require('finscholar.scholarshiplistview');
-const {ScholarshipPageView} = goog.require('finscholar.scholarshippageview');
+const {BasicView} = goog.require('basicview');
 const {homepage} = goog.require('finscholar.homepagecontroller.templates');
-const googDom = goog.require('goog.dom');
-const googSoy = goog.require('goog.soy');
-const jsactionActionFlow = goog.require('jsaction.ActionFlow');
-const jsactionDispatcher = goog.require('jsaction.Dispatcher');
-const jsactionEventContract = goog.require('jsaction.EventContract');
 
-const TEST_ERR_INPUT1 = 'A network error has occurred. Failed to load college data.';
-const TEST_ERR_INPUT2 = 'Please reload the page or select a different college.';
-const TEST_ERR_INPUT3 = 'Thanks!';
 
 /**
  * Class for the home page controller.
  */
-class HomePageController extends PageController {
-
-  /** 
-   * @param {!Element} container The HTML div where the main frame is rendered.
-   */
-  constructor(container) {
+class HomePageController extends BasicView {
+  constructor() {
     super();
-    /** @private @const {!Element} */
-    this.container_ = container;
-
-    /** @private @const {!jsactionEventContract} */
-    this.eventContract_ = new jsactionEventContract();
-
-    /** @private @const {!jsactionDispatcher} */
-    this.dispatcher_ = new jsactionDispatcher();
-
-    /** @private @const {!function(jsaction.ActionFlow): undefined} */
-    this.bindedNavbarOnclickHandler_ = this.handleNavbarOnclickEvent_.bind(this);
-
-    /** @private {number} */
-    this.navbarPageIndex_ = 0;
-
-    /** @private @const 
-     * {!Array<CollegeListView, ScholarshipListView, 
-     *     CollegePageView, ScholarshipPageView, ErrorPageView>} 
-     */
-    this.TEMPLATE_HANDLERS_ = [
-                               CollegeListView, 
-                               ScholarshipListView, 
-                               CollegePageView, 
-                               ScholarshipPageView, 
-                               ErrorPageView
-                               ];
-    
-    this.initJsaction_();
-
-    this.container_.innerHTML = this.getContent_();
-
-    /** @private @const {!Element} subView_*/
-    this.subView_ = /** @type {!Element} */ (googDom.getElement('content'));
-
-    this.renderPage_();
   }
 
   /**
-   * Sets up the event handlers for elements in the main frame.
-   * @private
+   * Loads the home page view.
+   * @override
    */
-  initJsaction_() {
-    // Events will be handled for all elements under this container.
-    this.eventContract_.addContainer(
-        /** @type {!Element} */ (googDom.getElement('main')));
-    // Register the event types we care about.
-    this.eventContract_.addEvent('click');
-    this.eventContract_.addEvent('dblclick');
-    this.eventContract_.dispatchTo(
-        this.dispatcher_.dispatch.bind(this.dispatcher_));
-    this.dispatcher_.registerHandlers(
-      'homepagecontroller',  // the namespace
-      null,                  // handler object
-      {
-        // action map
-        'clickAction': this.bindedNavbarOnclickHandler_,
-        'doubleClickAction' : this.bindedNavbarOnclickHandler_,
-      });
-  }
-
-  /**
-   * @return {!googSoy.data.SanitizedHtml} The rendered HTML of the common framework.
-   * @private
-   */
-  getContent_() {
-    return homepage();
-  }
-
-  /**
-   * Handles click and double click events on navbar.
-   * @param {!jsactionActionFlow} flow Contains the data related to the action.
-   *     and more. See actionflow.js.
-   * @private
-   */
-  handleNavbarOnclickEvent_(flow) {
-    const index = flow.node().getAttribute('index');
-    this.navbarPageIndex_ = parseInt(index, 10);
-    this.renderPage_();
-  }
-
-  /**
-   * Render the div with id 'content' based on the click event navber buttons.
-   * @private
-   */
-  renderPage_() {
-    // This if statement is temporarily added to enable showing the error page.
-    if (this.navbarPageIndex_ == 4) {
-      this.TEMPLATE_HANDLERS_[this.navbarPageIndex_].renderView(this.subView_, 
-        TEST_ERR_INPUT1,
-        TEST_ERR_INPUT2,
-        TEST_ERR_INPUT3);
-    } else {
-      // In actual product we'll only have this line in this function.
-      (new this.TEMPLATE_HANDLERS_[this.navbarPageIndex_]).renderView(this.subView_);
-    }
+  async renderView() {
+    super.setCurrentContent(homepage());
+    super.resetAndUpdate();
   }
 }
 

--- a/src/main/webapp/js/finscholar/homepagecontroller/homepagecontroller.js
+++ b/src/main/webapp/js/finscholar/homepagecontroller/homepagecontroller.js
@@ -26,15 +26,7 @@ const {homepage} = goog.require('finscholar.homepagecontroller.templates');
 class HomePageController extends BasicView {
   constructor() {
     super();
-  }
-
-  /**
-   * Loads the home page view.
-   * @override
-   */
-  async renderView() {
     super.setCurrentContent(homepage());
-    super.resetAndUpdate();
   }
 }
 

--- a/src/main/webapp/js/finscholar/homepagecontroller/homepagecontroller.soy
+++ b/src/main/webapp/js/finscholar/homepagecontroller/homepagecontroller.soy
@@ -11,40 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 {namespace finscholar.homepagecontroller.templates}
 {template .homepage}
-  <div class="mdl-card__supporting-text">
-    <h4>FINSCHOLAR</h4>
-    <p>This is the home page for our website :)</p>
-  </div>
-  <div id="temp-navbar">
-    <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect 
-        mdl-button--accent" index="0" 
-        jsaction="homepagecontroller.clickAction;dblclick:homepageController.doubleClickAction">
-      College List
-    </button>
-    <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect
-        mdl-button--accent" index="1" 
-        jsaction="homepagecontroller.clickAction;dblclick:homepageController.doubleClickAction">
-      Scholarship List
-    </button>
-    <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect 
-        mdl-button--accent" index="2" 
-        jsaction="homepagecontroller.clickAction;dblclick:homepageController.doubleClickAction">
-      Single College
-    </button>
-    <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect 
-        mdl-button--accent" index="3" 
-        jsaction="homepagecontroller.clickAction;dblclick:homepageController.doubleClickAction">
-      Single Scholarship
-    </button>
-    <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect 
-        mdl-button--accent" index="4" 
-        jsaction="homepagecontroller.clickAction;dblclick:homepageController.doubleClickAction">
-      Error Page
-    </button>
-  </div>
-  <div id="content">
-  </div>
+  <p>This is the home page for our website :)</p>
 {/template}


### PR DESCRIPTION
This pr removes content that is in the soy template for the home page and only leaves the content for the home page in the template. It also removes content that was moved elsewhere into the appstate and navbar classes.