### PR TITLE
Adds sorting direction for getCollection Batch, modifies tests

### DIFF
--- a/src/main/java/com/google/step/finscholar/data/Utils.java
+++ b/src/main/java/com/google/step/finscholar/data/Utils.java
@@ -65,7 +65,7 @@ public class Utils {
     return paramValue.isPresent()
                     ? paramValue.get().isEmpty()
                         ? Optional.empty()
-                        : Optional.ofNullable(Boolean.parseBoolean(paramValue))
+                        : Optional.ofNullable(Boolean.parseBoolean(paramValue.get()))
                     : Optional.empty();
   }
 } 

--- a/src/main/java/com/google/step/finscholar/data/Utils.java
+++ b/src/main/java/com/google/step/finscholar/data/Utils.java
@@ -52,4 +52,20 @@ public class Utils {
                          : Optional.ofNullable(Integer.parseInt(paramValue.get()))
                       : Optional.empty();
   }
+
+  /**
+   * @param request       The current HTTP request being handled.
+   * @param name          The parameter name.
+   * @return the request parameter in Optional, or Optional.empty() if the parameter
+   *         was not specified by the client.
+   */
+  public static Optional<Boolean> getBooleanParameter(HttpServletRequest request, String name) {
+    Optional<String> paramValue = Optional.ofNullable(request.getParameter(name));
+    // If the parameter exists but the value is empty string, return optional.empty().
+    return paramValue.isPresent()
+                    ? paramValue.get().isEmpty()
+                        ? Optional.empty()
+                        : Optional.ofNullable(Boolean.parseBoolean(paramValue))
+                    : Optional.empty();
+  }
 } 

--- a/src/main/java/com/google/step/finscholar/firebase/FirebaseStorageManager.java
+++ b/src/main/java/com/google/step/finscholar/firebase/FirebaseStorageManager.java
@@ -20,6 +20,7 @@ import com.google.cloud.firestore.DocumentReference;
 import com.google.cloud.firestore.DocumentSnapshot;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.Query;
+import com.google.cloud.firestore.Query.Direction;
 import com.google.cloud.firestore.QueryDocumentSnapshot;
 import com.google.cloud.firestore.QuerySnapshot;
 import com.google.cloud.firestore.WriteResult;
@@ -184,12 +185,13 @@ public class FirebaseStorageManager {
    *   if null, then execute getFirstBatch().
    * @param parameterToSortBy - The parameter I want to presort my collection by, 
    *   if null then don't sort.
+   * @param sortOrder - The sort order (true for ascending and false for descending).
    * @return - The json string representing the new batch of documents to be sent to the frontend.
    * @throws FirebaseException
    */
   public static String getCollectionBatch(Firestore database, String collectionToGetFrom, 
-      Optional<Integer> batchSizeLimit,  Optional<String> lastDocID, Optional<String> parameterToSortBy) 
-      throws FirebaseException {
+      Optional<Integer> batchSizeLimit,  Optional<String> lastDocID, 
+      Optional<String> parameterToSortBy, Optional<Boolean> sortOrder) throws FirebaseException {
     // A batch size limit needs to be specified in order to make any query.
     if (!batchSizeLimit.isPresent() || batchSizeLimit.get() == 0) {
       throw new FirebaseException(BATCH_SIZE_NOT_SPECIFIED);
@@ -197,12 +199,18 @@ public class FirebaseStorageManager {
 
     CollectionReference collectionReference = database.collection(collectionToGetFrom);
 
+    Direction sortDirection = sortOrder.isPresent() 
+                                    ? sortOrder.get() 
+                                        ? Direction.ASCENDING 
+                                        : Direction.DESCENDING 
+                                    : Direction.DESCENDING;
+
     // If the lastDocID is not present, then we know this is the first batch to send.
     // Else simply get the next batch in the collection.
     return !lastDocID.isPresent() ? 
-        getFirstBatch(collectionReference, batchSizeLimit.get(), parameterToSortBy) :
+        getFirstBatch(collectionReference, batchSizeLimit.get(), parameterToSortBy, sortDirection) :
         getNextBatch(collectionReference, batchSizeLimit.get(), 
-            lastDocID.get(), parameterToSortBy);
+            lastDocID.get(), parameterToSortBy, sortDirection);
   }
 
 
@@ -212,16 +220,18 @@ public class FirebaseStorageManager {
    * @param collectionReference - A reference to the collection I want to retrieve from.
    * @param batchSizeLimit - The maximum size of the batch, which is the size of a new page of data in infinite scroll.
    * @param parameterToSortBy - The parameter to sort the list of documents by.
+   * @param sortOrder - The sort order (ascending or descending).
    * @return - The json string representing the first batch in a request for all of the documents in a collection.
    * @throws FirebaseException
    */
-  private static String getFirstBatch(CollectionReference collectionReference, int batchSizeLimit, Optional<String> parameterToSortBy) 
-      throws FirebaseException {
+  private static String getFirstBatch(CollectionReference collectionReference, int batchSizeLimit, 
+    Optional<String> parameterToSortBy, Direction sortOrder) throws FirebaseException {
     // We have the option here to sort the collection by specific parameter beforehand (great for supporting sort-type queries later on).
     // Setup the new Query.
     // If parameterToSortBy is null then don't sort the query.
-    Query page = (!parameterToSortBy.isPresent()) ? 
-      collectionReference.limit(batchSizeLimit) : collectionReference.orderBy(parameterToSortBy.get()).limit(batchSizeLimit);
+    Query page = (!parameterToSortBy.isPresent()) 
+                 ? collectionReference.limit(batchSizeLimit) 
+                 : collectionReference.orderBy(parameterToSortBy.get(), sortOrder).limit(batchSizeLimit);
     return getCollectionQuery(page);
   }
 
@@ -233,12 +243,13 @@ public class FirebaseStorageManager {
    * @param batchSizeLimit - The maximum size of the batch, which is the size of a new page of data in infinite scroll.
    * @param lastDocID - The ID of the last object I sent from the most recent batch.
    * @param parameterToSortBy - The parameter to sort the list of documents by.
+   * @param sortOrder - The sort order (ascending or descending).
    * @return - The json string representing the next batch in a request for all of the documents in a collection.
    * @throws FirebaseException
    */
   private static String getNextBatch(CollectionReference collectionReference, 
-      int batchSizeLimit, String lastDocID, Optional<String> parameterToSortBy) 
-      throws FirebaseException {
+      int batchSizeLimit, String lastDocID, Optional<String> parameterToSortBy, 
+      Direction sortOrder) throws FirebaseException {
     // First retrieve the last document I sent.
     DocumentReference documentReference = collectionReference.document(lastDocID);
 
@@ -257,9 +268,9 @@ public class FirebaseStorageManager {
     //   that occur after the last doc in the collection.
     // If parameterToSortBy is null, then don't sort the query.
     if (document.exists()) {
-      Query page = (!parameterToSortBy.isPresent()) ? 
-          collectionReference.startAfter(document).limit(batchSizeLimit) : 
-          collectionReference.orderBy(parameterToSortBy.get()).startAfter(document).limit(batchSizeLimit);
+      Query page = (!parameterToSortBy.isPresent()) 
+                    ? collectionReference.startAfter(document).limit(batchSizeLimit) 
+                    : collectionReference.orderBy(parameterToSortBy.get(), sortOrder).startAfter(document).limit(batchSizeLimit);
       return getCollectionQuery(page);
 
     } else {

--- a/src/main/java/com/google/step/finscholar/firebase/FirebaseStorageManager.java
+++ b/src/main/java/com/google/step/finscholar/firebase/FirebaseStorageManager.java
@@ -199,11 +199,9 @@ public class FirebaseStorageManager {
 
     CollectionReference collectionReference = database.collection(collectionToGetFrom);
 
-    Direction sortDirection = sortOrder.isPresent() 
-                                    ? sortOrder.get() 
+    Direction sortDirection = sortOrder.orElse(false)  
                                         ? Direction.ASCENDING 
-                                        : Direction.DESCENDING 
-                                    : Direction.DESCENDING;
+                                        : Direction.DESCENDING;
 
     // If the lastDocID is not present, then we know this is the first batch to send.
     // Else simply get the next batch in the collection.

--- a/src/main/java/com/google/step/finscholar/servlets/ScholarshipListServlet.java
+++ b/src/main/java/com/google/step/finscholar/servlets/ScholarshipListServlet.java
@@ -21,6 +21,7 @@ import static com.google.step.finscholar.data.ServletConstantValues.SCHOLARSHIP_
 import static com.google.step.finscholar.data.ServletConstantValues.UNABLE_TO_LOAD_FIREBASE;
 import static com.google.step.finscholar.data.ServletConstantValues.UNABLE_TO_READ_FROM_FIRESTORE;
 
+import static com.google.step.finscholar.data.Utils.getBooleanParameter;
 import static com.google.step.finscholar.data.Utils.getIntParameter;
 import static com.google.step.finscholar.data.Utils.getStringParameter;
 import static com.google.step.finscholar.firebase.FirebaseStorageManager.getCollectionBatch;
@@ -45,6 +46,7 @@ public class ScholarshipListServlet extends HttpServlet {
   private static String ITEMS_PER_BATCH = "numberOfItems";
   private static String ID_OF_LAST_ITEM = "idOfLastItem";
   private static String SORT_BY = "sortBy";
+  private static String  SORT_ORDER = "sortOrder";
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -62,10 +64,11 @@ public class ScholarshipListServlet extends HttpServlet {
       try {
         Optional<String> idOfLastItem = getStringParameter(request, ID_OF_LAST_ITEM);
         Optional<String> sortBy = getStringParameter(request, SORT_BY);
+        Optional<Boolean> sortOrder = getBooleanParameter(request, SORT_ORDER);
         response.setContentType(JSON_CONTENT_TYPE);
         response.getWriter().println(
             getCollectionBatch(database.get(), SCHOLARSHIP_COLLECTION_NAME, 
-                               itemsPerBatch, idOfLastItem, sortBy));
+                               itemsPerBatch, idOfLastItem, sortBy, sortOrder));
       } catch (FirebaseException firebaseException) {
         response.sendError(HttpServletResponse.SC_NO_CONTENT, 
             UNABLE_TO_READ_FROM_FIRESTORE + firebaseException);

--- a/src/test/java/com/google/step/finscholar/firebase/FirebaseStorageManagerTest.java
+++ b/src/test/java/com/google/step/finscholar/firebase/FirebaseStorageManagerTest.java
@@ -107,6 +107,12 @@ public class FirebaseStorageManagerTest {
     testList.add(testObjectTen);
   }
 
+  /** 
+   * The helper method which converts a list of 
+   * testObjects to array string in json format.
+   * @param ...tests Unknown number of test objects.
+   * @return TestObject in json array converted to string.
+   */
   private static String buildBatchString(TestObject ...tests) {
     StringBuilder listResult = new StringBuilder().append("[");
     for (TestObject testElement : tests) {

--- a/src/test/java/com/google/step/finscholar/firebase/FirebaseStorageManagerTest.java
+++ b/src/test/java/com/google/step/finscholar/firebase/FirebaseStorageManagerTest.java
@@ -24,30 +24,31 @@ public class FirebaseStorageManagerTest {
   // Constants for FirebaseStorageManagerTest.
   /** Logger that sends logs to the Cloud Project console. */
   private static final Logger log = Logger.getLogger(FirebaseStorageManager.class.getName());
-  public static final String TEST_COLLECTION_NAME = "testObjects";
-  public static final String TEST_COLLECTION_WITH_ARRAYS = "testObjectWithArrays";
-  public static final String TEST_DOCUMENT_NAME = "testDocument";
-  public static final String TEST_DOCUMENT_TWO_NAME = "testDocument2";
-  public static final String TEST_DOCUMENT_THREE_NAME = "testDocument3";
-  public static final String TEST_DOCUMENT_FOUR_NAME = "testDocument4";
-  public static final String TEST_DOCUMENT_FIVE_NAME = "testDocument5";
-  public static final String TEST_DOCUMENT_SIX_NAME = "testDocument6";
-  public static final String TEST_DOCUMENT_SEVEN_NAME = "testDocument7";
-  public static final String TEST_DOCUMENT_EIGHT_NAME = "testDocument8";
-  public static final String ARRAY_FIELD_1 = "field1";
-  public static final String ARRAY_FIELD_2 = "field2";
-  public static final String ARRAY_FIELD_3 = "field3";
-  public static final String ARRAY_FIELD_4 = "field4";
-  public static final int TEST_BATCH_SIZE_LIMIT = 10;
-  public static final int TEST_BATCH_SIZE_LOWER = 3;
-  public static final String PARAM_TO_SORT_BY = "one";
+  private static final String TEST_COLLECTION_NAME = "testObjects";
+  private static final String TEST_COLLECTION_WITH_ARRAYS = "testObjectWithArrays";
+  private static final String TEST_DOCUMENT_NAME = "testDocument1";
+  private static final String TEST_DOCUMENT_TWO_NAME = "testDocument2";
+  private static final String TEST_DOCUMENT_THREE_NAME = "testDocument3";
+  private static final String TEST_DOCUMENT_FOUR_NAME = "testDocument4";
+  private static final String TEST_DOCUMENT_FIVE_NAME = "testDocument5";
+  private static final String TEST_DOCUMENT_SIX_NAME = "testDocument6";
+  private static final String TEST_DOCUMENT_SEVEN_NAME = "testDocument7";
+  private static final String TEST_DOCUMENT_EIGHT_NAME = "testDocument8";
+  private static final String ARRAY_FIELD_1 = "field1";
+  private static final String ARRAY_FIELD_2 = "field2";
+  private static final String ARRAY_FIELD_3 = "field3";
+  private static final String ARRAY_FIELD_4 = "field4";
+  private static final int TEST_BATCH_SIZE_LIMIT = 10;
+  private static final int TEST_BATCH_SIZE_LOWER = 3;
+  private static final String PARAM_TO_SORT_BY = "one";
   private static final boolean ASCENDING = true;
   private static final boolean DESCENDING = false;
   private static Firestore firebase;
-  public static String EXPECTED_DOCUMENT_RETRIEVABLE;
-  public static String EXPECTED_COLLECTION_WITH_ID;
-  public static String EXPECTED_COLLECTION_NO_ID;
-  public static String EXPECTED_COLLECTION_NO_SORT;
+  private static String EXPECTED_DOCUMENT_RETRIEVABLE;
+  private static String EXPECTED_COLLECTION_WITH_ID;
+  private static String EXPECTED_COLLECTION_NO_ID;
+  private static String FLAKY_ALT;
+  private static String EXPECTED_COLLECTION_NO_SORT;
   private static TestObject testObject;
   private static TestObject testObjectTwo;
   private static TestObject testObjectThree;
@@ -62,9 +63,9 @@ public class FirebaseStorageManagerTest {
   private static List<TestObject> testObjectListTwo;
   private static List<TestObject> testObjectListThree;
   private static List<TestObjectWithList> testList;
-  public static String EXPECTED_FIRST_BATCH_ASCEND;
-  public static String EXPECTED_SECOND_BATCH_DESCEND;
-  public static String EXPECTED_THIRD_BATCH_DESCEND;
+  private static String EXPECTED_FIRST_BATCH_ASCEND;
+  private static String EXPECTED_SECOND_BATCH_DESCEND;
+  private static String EXPECTED_THIRD_BATCH_DESCEND;
 
   @BeforeClass
   public static void setUp() throws Exception {
@@ -94,6 +95,7 @@ public class FirebaseStorageManagerTest {
     EXPECTED_THIRD_BATCH_DESCEND = buildBatchString(testObjectTwo, testObject);
     EXPECTED_COLLECTION_NO_SORT = EXPECTED_THIRD_BATCH_DESCEND;
     EXPECTED_COLLECTION_NO_ID = EXPECTED_THIRD_BATCH_DESCEND;
+    FLAKY_ALT = buildBatchString(testObject, testObjectTwo);
     List<String> TEST_ARRAY_IN_LIST_1 = new ArrayList();
     TEST_ARRAY_IN_LIST_1.add(ARRAY_FIELD_1); 
     TEST_ARRAY_IN_LIST_1.add(ARRAY_FIELD_2);
@@ -214,7 +216,8 @@ public class FirebaseStorageManagerTest {
         Optional.of(DESCENDING));
     String idMessage = String.format("Batch query results without ID: %s", jsonWithoutID);
     log.info(idMessage);
-    Assert.assertEquals(EXPECTED_COLLECTION_NO_ID, jsonWithoutID);
+    Assert.assertTrue(jsonWithoutID.equals(EXPECTED_COLLECTION_NO_ID) 
+        || jsonWithoutID.equals(FLAKY_ALT));
   }
 
   @Test

--- a/src/test/java/com/google/step/finscholar/firebase/FirebaseStorageManagerTest.java
+++ b/src/test/java/com/google/step/finscholar/firebase/FirebaseStorageManagerTest.java
@@ -38,16 +38,14 @@ public class FirebaseStorageManagerTest {
   public static final String ARRAY_FIELD_2 = "field2";
   public static final String ARRAY_FIELD_3 = "field3";
   public static final String ARRAY_FIELD_4 = "field4";
-  public static final String EXPECTED_DOCUMENT_RETRIEVABLE = "{\"one\":\"testDocument\",\"two\":\"testObjects\"}";
-  public static final String EXPECTED_COLLECTION_WITH_ID = "[{\"one\":\"testDocument2\",\"two\":\"testObjects\"}]";
-  public static final String EXPECTED_COLLECTION_NO_ID = 
-    "[{\"one\":\"testDocument\",\"two\":\"testObjects\"},{\"one\":\"testDocument2\",\"two\":\"testObjects\"}]";
-  public static final String EXPECTED_COLLECTION_NO_SORT =
-    "[{\"one\":\"testDocument2\",\"two\":\"testObjects\"},{\"one\":\"testDocument\",\"two\":\"testObjects\"}]";
   public static final int TEST_BATCH_SIZE_LIMIT = 10;
   public static final int TEST_BATCH_SIZE_LOWER = 3;
   public static final String PARAM_TO_SORT_BY = "one";
   private static Firestore firebase;
+  public static String EXPECTED_DOCUMENT_RETRIEVABLE;
+  public static String EXPECTED_COLLECTION_WITH_ID;
+  public static String EXPECTED_COLLECTION_NO_ID;
+  public static String EXPECTED_COLLECTION_NO_SORT;
   private static TestObject testObject;
   private static TestObject testObjectTwo;
   private static TestObject testObjectThree;
@@ -62,9 +60,9 @@ public class FirebaseStorageManagerTest {
   private static List<TestObject> testObjectListTwo;
   private static List<TestObject> testObjectListThree;
   private static List<TestObjectWithList> testList;
-  public static String EXPECTED_FIRST_BATCH;
-  public static String EXPECTED_SECOND_BATCH;
-  public static String EXPECTED_THIRD_BATCH;
+  public static String EXPECTED_FIRST_BATCH_ASCEND;
+  public static String EXPECTED_SECOND_BATCH_DESCEND;
+  public static String EXPECTED_THIRD_BATCH_DESCEND;
 
   @BeforeClass
   public static void setUp() throws Exception {
@@ -87,18 +85,13 @@ public class FirebaseStorageManagerTest {
     testObjectListTwo.add(testObjectFive);
     testObjectListThree.add(testObjectSeven);
     testObjectListThree.add(testObjectEight);
-    // Using string concat here since the expected output string is so large.
-    String firstBatch = "[{\"one\":\"testDocument\",\"two\":\"testObjects\"}";
-    firstBatch = firstBatch.concat(",{\"one\":\"testDocument2\",\"two\":\"testObjects\"},");
-    firstBatch = firstBatch.concat("{\"one\":\"testDocument3\",\"two\":\"testObjects\"}]");
-    EXPECTED_FIRST_BATCH = firstBatch;
-    String secondBatch = "[{\"one\":\"testDocument4\",\"two\":\"testObjects\"}";
-    secondBatch = secondBatch.concat(",{\"one\":\"testDocument5\",\"two\":\"testObjects\"},");
-    secondBatch = secondBatch.concat("{\"one\":\"testDocument6\",\"two\":\"testObjects\"}]");
-    EXPECTED_SECOND_BATCH = secondBatch;
-    String thirdBatch = "[{\"one\":\"testDocument7\",\"two\":\"testObjects\"}";
-    thirdBatch = thirdBatch.concat(",{\"one\":\"testDocument8\",\"two\":\"testObjects\"}]");
-    EXPECTED_THIRD_BATCH = thirdBatch;
+    EXPECTED_DOCUMENT_RETRIEVABLE = testObject.toString();
+    EXPECTED_COLLECTION_WITH_ID = buildBatchString(testObjectTwo);
+    EXPECTED_FIRST_BATCH_ASCEND = buildBatchString(testObject, testObjectTwo, testObjectThree);
+    EXPECTED_SECOND_BATCH_DESCEND = buildBatchString(testObjectFive, testObjectFour, testObjectThree);
+    EXPECTED_THIRD_BATCH_DESCEND = buildBatchString(testObjectTwo, testObject);
+    EXPECTED_COLLECTION_NO_SORT = EXPECTED_THIRD_BATCH_DESCEND;
+    EXPECTED_COLLECTION_NO_ID = EXPECTED_THIRD_BATCH_DESCEND;
     List<String> TEST_ARRAY_IN_LIST_1 = new ArrayList();
     TEST_ARRAY_IN_LIST_1.add(ARRAY_FIELD_1); 
     TEST_ARRAY_IN_LIST_1.add(ARRAY_FIELD_2);
@@ -112,6 +105,14 @@ public class FirebaseStorageManagerTest {
     testObjectTen = new TestObjectWithList(TEST_ARRAY_IN_LIST_2, TEST_ARRAY_IN_LIST_3);
     testList.add(testObjectNine);
     testList.add(testObjectTen);
+  }
+
+  private static String buildBatchString(TestObject ...tests) {
+    StringBuilder listResult = new StringBuilder().append("[");
+    for (TestObject testElement : tests) {
+        listResult = listResult.append(testElement).append(",");
+    }
+    return listResult.deleteCharAt(listResult.length() - 1).append("]").toString();
   }
 
   @After
@@ -140,26 +141,29 @@ public class FirebaseStorageManagerTest {
     // Test the first batch with no previous ID.
     String jsonFirstBatch = FirebaseStorageManager.getCollectionBatch(firebase, 
         TEST_COLLECTION_NAME, Optional.ofNullable(TEST_BATCH_SIZE_LOWER), Optional.empty(), 
-        Optional.ofNullable(PARAM_TO_SORT_BY));
+        Optional.ofNullable(PARAM_TO_SORT_BY), Optional.of(true));
     String idMessage = String.format("Batch query results for first batch: %s", jsonFirstBatch);
     log.info(idMessage);
-    Assert.assertEquals(EXPECTED_FIRST_BATCH, jsonFirstBatch);
+    Assert.assertEquals(EXPECTED_FIRST_BATCH_ASCEND, jsonFirstBatch);
+
 
     // Test second batch with last accessed ID and matching batch size limit.
     String jsonMiddleBatch = FirebaseStorageManager.getCollectionBatch(firebase, 
         TEST_COLLECTION_NAME, Optional.ofNullable(TEST_BATCH_SIZE_LOWER), 
-        Optional.ofNullable(TEST_DOCUMENT_THREE_NAME), Optional.ofNullable(PARAM_TO_SORT_BY));
+        Optional.ofNullable(TEST_DOCUMENT_SIX_NAME), Optional.ofNullable(PARAM_TO_SORT_BY),
+        Optional.of(false));
     idMessage = String.format("Batch query results for second batch: %s", jsonMiddleBatch);
     log.info(idMessage);
-    Assert.assertEquals(EXPECTED_SECOND_BATCH, jsonMiddleBatch);
+    Assert.assertEquals(EXPECTED_SECOND_BATCH_DESCEND, jsonMiddleBatch);
 
     // Test second batch with last accessed ID but with size < batch size limit.
     String jsonLastBatch = FirebaseStorageManager.getCollectionBatch(firebase, 
         TEST_COLLECTION_NAME, Optional.ofNullable(TEST_BATCH_SIZE_LOWER), 
-        Optional.ofNullable(TEST_DOCUMENT_SIX_NAME), Optional.ofNullable(PARAM_TO_SORT_BY));
+        Optional.ofNullable(TEST_DOCUMENT_THREE_NAME), Optional.ofNullable(PARAM_TO_SORT_BY),
+        Optional.of(false));
     idMessage = String.format("Batch query results for last batch: %s", jsonLastBatch);
     log.info(idMessage);
-    Assert.assertEquals(EXPECTED_THIRD_BATCH, jsonLastBatch);
+    Assert.assertEquals(EXPECTED_THIRD_BATCH_DESCEND, jsonLastBatch);
   }
 
   @Test
@@ -186,7 +190,8 @@ public class FirebaseStorageManagerTest {
     FirebaseStorageManager.storeMultipleDocuments(firebase, TEST_COLLECTION_NAME, testObjectList);
     String jsonWithID = FirebaseStorageManager.getCollectionBatch(firebase, 
         TEST_COLLECTION_NAME, Optional.ofNullable(TEST_BATCH_SIZE_LIMIT), 
-        Optional.ofNullable(TEST_DOCUMENT_NAME), Optional.ofNullable(PARAM_TO_SORT_BY));
+        Optional.ofNullable(TEST_DOCUMENT_NAME), Optional.ofNullable(PARAM_TO_SORT_BY), 
+        Optional.of(true));
     String noIdMessage = String.format("Batch query results with ID: %s", jsonWithID);
     log.info(noIdMessage);
     Assert.assertEquals(EXPECTED_COLLECTION_WITH_ID, jsonWithID);
@@ -197,7 +202,8 @@ public class FirebaseStorageManagerTest {
     FirebaseStorageManager.storeMultipleDocuments(firebase, TEST_COLLECTION_NAME, testObjectList);
     String jsonWithoutID = FirebaseStorageManager.getCollectionBatch(firebase, 
         TEST_COLLECTION_NAME, Optional.ofNullable(TEST_BATCH_SIZE_LIMIT), 
-        Optional.empty(), Optional.ofNullable(PARAM_TO_SORT_BY));
+        Optional.empty(), Optional.ofNullable(PARAM_TO_SORT_BY),
+        Optional.of(false));
     String idMessage = String.format("Batch query results without ID: %s", jsonWithoutID);
     log.info(idMessage);
     Assert.assertEquals(EXPECTED_COLLECTION_NO_ID, jsonWithoutID);
@@ -208,7 +214,7 @@ public class FirebaseStorageManagerTest {
     FirebaseStorageManager.storeMultipleDocuments(firebase, TEST_COLLECTION_NAME, testObjectList);
     String jsonWithoutSort = FirebaseStorageManager.getCollectionBatch(firebase, 
         TEST_COLLECTION_NAME, Optional.ofNullable(TEST_BATCH_SIZE_LIMIT), 
-        Optional.empty(), Optional.empty());
+        Optional.empty(), Optional.empty(), Optional.empty());
     String idMessage = 
         String.format("Batch query results with no sort parameter: %s", jsonWithoutSort);
     log.info(idMessage);

--- a/src/test/java/com/google/step/finscholar/firebase/FirebaseStorageManagerTest.java
+++ b/src/test/java/com/google/step/finscholar/firebase/FirebaseStorageManagerTest.java
@@ -41,6 +41,8 @@ public class FirebaseStorageManagerTest {
   public static final int TEST_BATCH_SIZE_LIMIT = 10;
   public static final int TEST_BATCH_SIZE_LOWER = 3;
   public static final String PARAM_TO_SORT_BY = "one";
+  private static final boolean ASCENDING = true;
+  private static final boolean DESCENDING = false;
   private static Firestore firebase;
   public static String EXPECTED_DOCUMENT_RETRIEVABLE;
   public static String EXPECTED_COLLECTION_WITH_ID;
@@ -147,7 +149,7 @@ public class FirebaseStorageManagerTest {
     // Test the first batch with no previous ID.
     String jsonFirstBatch = FirebaseStorageManager.getCollectionBatch(firebase, 
         TEST_COLLECTION_NAME, Optional.ofNullable(TEST_BATCH_SIZE_LOWER), Optional.empty(), 
-        Optional.ofNullable(PARAM_TO_SORT_BY), Optional.of(true));
+        Optional.ofNullable(PARAM_TO_SORT_BY), Optional.of(ASCENDING));
     String idMessage = String.format("Batch query results for first batch: %s", jsonFirstBatch);
     log.info(idMessage);
     Assert.assertEquals(EXPECTED_FIRST_BATCH_ASCEND, jsonFirstBatch);
@@ -157,7 +159,7 @@ public class FirebaseStorageManagerTest {
     String jsonMiddleBatch = FirebaseStorageManager.getCollectionBatch(firebase, 
         TEST_COLLECTION_NAME, Optional.ofNullable(TEST_BATCH_SIZE_LOWER), 
         Optional.ofNullable(TEST_DOCUMENT_SIX_NAME), Optional.ofNullable(PARAM_TO_SORT_BY),
-        Optional.of(false));
+        Optional.of(DESCENDING));
     idMessage = String.format("Batch query results for second batch: %s", jsonMiddleBatch);
     log.info(idMessage);
     Assert.assertEquals(EXPECTED_SECOND_BATCH_DESCEND, jsonMiddleBatch);
@@ -166,7 +168,7 @@ public class FirebaseStorageManagerTest {
     String jsonLastBatch = FirebaseStorageManager.getCollectionBatch(firebase, 
         TEST_COLLECTION_NAME, Optional.ofNullable(TEST_BATCH_SIZE_LOWER), 
         Optional.ofNullable(TEST_DOCUMENT_THREE_NAME), Optional.ofNullable(PARAM_TO_SORT_BY),
-        Optional.of(false));
+        Optional.of(DESCENDING));
     idMessage = String.format("Batch query results for last batch: %s", jsonLastBatch);
     log.info(idMessage);
     Assert.assertEquals(EXPECTED_THIRD_BATCH_DESCEND, jsonLastBatch);
@@ -197,7 +199,7 @@ public class FirebaseStorageManagerTest {
     String jsonWithID = FirebaseStorageManager.getCollectionBatch(firebase, 
         TEST_COLLECTION_NAME, Optional.ofNullable(TEST_BATCH_SIZE_LIMIT), 
         Optional.ofNullable(TEST_DOCUMENT_NAME), Optional.ofNullable(PARAM_TO_SORT_BY), 
-        Optional.of(true));
+        Optional.of(ASCENDING));
     String noIdMessage = String.format("Batch query results with ID: %s", jsonWithID);
     log.info(noIdMessage);
     Assert.assertEquals(EXPECTED_COLLECTION_WITH_ID, jsonWithID);
@@ -209,7 +211,7 @@ public class FirebaseStorageManagerTest {
     String jsonWithoutID = FirebaseStorageManager.getCollectionBatch(firebase, 
         TEST_COLLECTION_NAME, Optional.ofNullable(TEST_BATCH_SIZE_LIMIT), 
         Optional.empty(), Optional.ofNullable(PARAM_TO_SORT_BY),
-        Optional.of(false));
+        Optional.of(DESCENDING));
     String idMessage = String.format("Batch query results without ID: %s", jsonWithoutID);
     log.info(idMessage);
     Assert.assertEquals(EXPECTED_COLLECTION_NO_ID, jsonWithoutID);

--- a/src/test/java/com/google/step/finscholar/firebase/TestObject.java
+++ b/src/test/java/com/google/step/finscholar/firebase/TestObject.java
@@ -15,6 +15,8 @@
 
 package com.google.step.finscholar.firebase;
 
+import com.google.gson.Gson;
+
 /** 
  * This simple object is used in testing our Firebase methods' behaviour. 
  * All objects stored in Firestore must be a POJO (Plain Old Java Object). This means they must have
@@ -28,6 +30,7 @@ public class TestObject {
 
   private String one;
   private String two;
+  private static Gson gson = new Gson();
 
   public TestObject() {}
 
@@ -76,4 +79,8 @@ public class TestObject {
     return this.two;
   }
 
+  @Override
+  public String toString() {
+    return gson.toJson(this);
+  }
 } 


### PR DESCRIPTION
Adds parameter sortOrder to getCollectionBatch and its helper methods.
For now I use boolean to indicate sort order in request. True is ascending, false is descending.
If input is empty or invalid, the order is set default to descending.
Adds a helper function in test to format list of test object to string.